### PR TITLE
fix: verify publish manifests before release

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -62,7 +62,7 @@ jobs:
         uses: changesets/action@v1
         timeout-minutes: 10
         with:
-          publish: nix develop --accept-flake-config -c bash -c "export CI=true; pnpm changeset publish"
+          publish: nix develop --accept-flake-config -c bash -c "export CI=true; pnpm changeset:verify-publish-manifests; pnpm changeset publish"
           createGithubReleases: ${{ github.ref == 'refs/heads/main' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -107,6 +107,7 @@ jobs:
             patch -p0 --forward < patches/snapshot_version.patch || true
             cd ../..
 
+            pnpm changeset:verify-publish-manifests
             pnpm build
             pnpm build:reactnative
             pnpm changeset publish --no-git-tag --snapshot canary --tag canary

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -55,6 +55,7 @@ jobs:
           patch -p0 --forward < patches/snapshot_version.patch || true
           cd ../..
 
+          pnpm changeset:verify-publish-manifests
           pnpm build
           pnpm build:reactnative
           pnpm changeset publish --no-git-tag --snapshot \$snapshot --tag snapshot

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "preview": "pnpm --filter vite-core preview",
     "reset": "pnpm clean && pnpm build && pnpm preview",
     "changeset": "changeset",
+    "changeset:verify-publish-manifests": "node scripts/verify-publish-manifests.mjs",
     "version": "changeset version",
     "typecheck": "pnpm run --r --parallel --filter \"!@fedimint/react-native\" --filter \"!@fedimint/react-native-bindings\" typecheck",
     "coverage": "vitest run --coverage",

--- a/scripts/verify-publish-manifests.mjs
+++ b/scripts/verify-publish-manifests.mjs
@@ -1,0 +1,62 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const rootDir = process.cwd()
+const packagesDir = join(rootDir, 'packages')
+const dependencyFields = [
+  'dependencies',
+  'optionalDependencies',
+  'peerDependencies',
+]
+
+const packageDirs = readdirSync(packagesDir, { withFileTypes: true })
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => join(packagesDir, entry.name))
+
+const failures = []
+
+for (const packageDir of packageDirs) {
+  const packageJsonPath = join(packageDir, 'package.json')
+  const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf8'))
+
+  if (pkg.private) {
+    continue
+  }
+
+  const workspaceProtocolEntries = dependencyFields.flatMap((field) => {
+    const dependencies = pkg[field] ?? {}
+    return Object.entries(dependencies)
+      .filter(
+        ([, version]) =>
+          typeof version === 'string' && version.startsWith('workspace:'),
+      )
+      .map(([name, version]) => `${field}.${name}=${version}`)
+  })
+
+  if (workspaceProtocolEntries.length > 0) {
+    failures.push({
+      name: pkg.name,
+      entries: workspaceProtocolEntries,
+    })
+  }
+}
+
+if (failures.length > 0) {
+  console.error(
+    [
+      'Refusing to publish: one or more publishable package manifests still contain workspace protocol references.',
+      'This check must run after `changeset version` has rewritten internal dependency ranges.',
+      '',
+      ...failures.flatMap(({ name, entries }) => [
+        `${name}:`,
+        ...entries.map((entry) => `- ${entry}`),
+        '',
+      ]),
+    ]
+      .join('\n')
+      .trim(),
+  )
+  process.exit(1)
+}
+
+console.log('Verified all publishable package manifests are publish-safe.')


### PR DESCRIPTION
## Summary
- add a release-time verifier for publishable package manifests under packages/
- fail stable, canary, and snapshot publishes if any publishable package still has workspace protocol references in dependencies, optionalDependencies, or peerDependencies
- enforce the existing expectation that Changesets versioning must rewrite internal package references before npm publish

## Why
The repo keeps workspace:* references in source manifests, and other published packages already rely on the release flow to rewrite those to concrete semver. This PR makes that assumption explicit and prevents broken publishes from reaching npm.

## Validation
- ran the verifier directly against the current source tree to confirm it fails before Changesets rewriting
- wired the verifier into stable, canary, and snapshot release workflows before pnpm changeset publish
- kept source package manifests unchanged
